### PR TITLE
[현다솜] feat: Table 설정 적용 + 로직 추가

### DIFF
--- a/src/Components/Table/index.tsx
+++ b/src/Components/Table/index.tsx
@@ -1,58 +1,51 @@
 import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { DataGrid } from '@mui/x-data-grid';
+
+import { getColGrid, getRowGrid, ALL_CATEGORY } from 'Utils/Constants';
 import {
-  PRODUCT_CATEGORY,
-  ORDER_CATEGORY,
-  RELEASE_CATEGORY,
-} from 'Utils/Constants';
-import { DataInterface } from 'Utils/Interfaces';
+  DataInterface,
+  ColDataInterface,
+  RowDataInterface,
+} from 'Utils/Interfaces';
 
-const getColGrid = (
-  columns: string[]
-): { field: string; headerName: string; width: number }[] => {
-  return columns.map((column: string, index: number) => {
-    return { field: `col${index + 1}`, headerName: column, width: 150 };
-  });
-};
+const testCategory = [
+  '매핑상태',
+  '상품코드',
+  '주문명',
+  '주문번호',
+  '주문수량',
+  '출고수량',
+];
 
-interface StringObjKey {
-  [key: string | number]: string | number;
-}
-
-const getRowGrid = (datas: any[], rowData: any[]) => {
-  return datas.map((data: any, index: number) => {
-    const newData: StringObjKey = { id: index + 1 };
-
-    for (let i = 0; i < rowData.length; i++) {
-      console.log(data, rowData[i].headerName);
-      newData[`col${i + 1}`] = data.상품[rowData[i].headerName];
-    }
-    return newData;
-  });
-};
 interface TableProps {
   datas: DataInterface[] | null;
 }
 
 const Table: React.FC<TableProps> = ({ datas }) => {
-  const [columns, setColumns] = useState<any[]>([]);
-  const [rows, setRows] = useState<any[]>([]);
+  const [columns, setColumns] = useState<ColDataInterface[]>([]);
+  const [rows, setRows] = useState<RowDataInterface[]>([]);
+
   useEffect(() => {
     if (datas) {
-      setColumns(getColGrid(PRODUCT_CATEGORY));
-      setRows(getRowGrid([...datas, ...datas], columns));
+      setColumns(getColGrid(ALL_CATEGORY));
+      setRows(getRowGrid([...datas, ...datas], getColGrid(ALL_CATEGORY)));
       console.log(rows, columns);
     }
   }, [datas]);
   return (
     <TableWrap>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        pageSize={rows.length}
-        autoHeight
-      />
+      {rows.length > 0 && (
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          pageSize={rows.length}
+          rowsPerPageOptions={[rows.length]}
+          rowHeight={100}
+          disableExtendRowFullWidth={true}
+          hideFooterPagination
+        />
+      )}
     </TableWrap>
   );
 };
@@ -66,7 +59,7 @@ const TableWrap = styled.section`
   border: 1px solid #dddddd;
   border-radius: 10px;
   box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.1);
-  overflow: scroll;
+  overflow-y: scroll;
 `;
 
 export default Table;

--- a/src/Utils/Constants/index.tsx
+++ b/src/Utils/Constants/index.tsx
@@ -1,3 +1,10 @@
+import {
+  DataInterface,
+  ColDataInterface,
+  RowDataInterface,
+  StringObjKey,
+} from 'Utils/Interfaces';
+
 export const PRODUCT_CATEGORY = [
   '상품코드',
   '상품명',
@@ -29,6 +36,14 @@ export const RELEASE_CATEGORY = [
   '출고요청자',
   '출고요청일자',
   '출고창고명',
+];
+
+export const ROOT_CATEGORY = [
+  '데이터출처',
+  '출고서파일명',
+  '엑셀행순번',
+  '매핑상태',
+  '재고부족여부',
 ];
 
 export const ALL_CATEGORY = [
@@ -84,3 +99,92 @@ export const ModalInfo = [
   ['option', '출고 유형', '오전(10:00)출고'],
   ['text', '파일명', '테스트_콜로상사주문서_test.xls'],
 ];
+
+const CategoryType: { [key: string]: number } = {
+  데이터출처: 4,
+  출고서파일명: 10,
+  엑셀행순번: 4,
+  매핑상태: 7,
+  재고부족여부: 6,
+  상품코드: 10,
+  상품명: 15,
+  상품가격: 6,
+  상품수량: 4,
+  연관상품ID: 4,
+  주문서양식: 7,
+  주문명: 15,
+  주문번호: 13,
+  주문수량: 4,
+  주문단위: 4,
+  주문자명: 4,
+  주문자연락처: 15,
+  수취인명: 4,
+  수취인연락처: 15,
+  메모: 4,
+  택배사명: 5,
+  출고코드: 10,
+  출고수량: 4,
+  출고상태: 5,
+  출고유형: 5,
+  출고요청업체: 5,
+  출고요청자: 4,
+  출고요청일자: 12,
+  출고창고명: 5,
+};
+
+const getWidth = (column: string | number) => {
+  const size: number = CategoryType[column] * 10;
+
+  return size;
+};
+
+export const getColGrid = (columns: string[]): ColDataInterface[] => {
+  return columns.map((column: string, index: number) => {
+    return {
+      field: `col${index + 1}`,
+      headerName: column,
+      minWidth: getWidth(column),
+    };
+  });
+};
+
+export const getLocation = (category: string): string => {
+  if (PRODUCT_CATEGORY.find((el) => el === category)) {
+    return 'product';
+  } else if (ORDER_CATEGORY.find((el) => el === category)) {
+    return 'order';
+  } else if (RELEASE_CATEGORY.find((el) => el === category)) {
+    return 'release';
+  } else {
+    return 'root';
+  }
+};
+
+export const getRowGrid = (
+  datas: DataInterface[],
+  rowData: ColDataInterface[]
+): RowDataInterface[] => {
+  return datas.map((data: DataInterface, index: number) => {
+    const newData: RowDataInterface = { id: index + 1 };
+
+    if (data && data.상품 && data.주문 && data.출고) {
+      for (let i = 0; i < rowData.length; i++) {
+        switch (getLocation(rowData[i].headerName)) {
+          case 'product':
+            newData[`col${i + 1}`] = data.상품[rowData[i].headerName];
+            break;
+          case 'order':
+            newData[`col${i + 1}`] = data.주문[rowData[i].headerName];
+            break;
+          case 'release':
+            newData[`col${i + 1}`] = data.출고[rowData[i].headerName];
+            break;
+          default:
+            newData[`col${i + 1}`] = data[rowData[i].headerName];
+            break;
+        }
+      }
+    }
+    return newData;
+  });
+};

--- a/src/Utils/Interfaces/index.tsx
+++ b/src/Utils/Interfaces/index.tsx
@@ -1,4 +1,51 @@
+export interface StringObjKey {
+  [key: string | number]: string | number | undefined;
+}
+
+export interface ColDataInterface {
+  field: string;
+  headerName: string;
+  minWidth: number;
+}
+
+export interface RowDataInterface {
+  [key: string | number]: string | number | undefined;
+  id: number;
+  col1?: string | number;
+  col2?: string | number;
+  col3?: string | number;
+  col4?: string | number;
+  col5?: string | number;
+  col6?: string | number;
+  col7?: string | number;
+  col8?: string | number;
+  col9?: string | number;
+  col10?: string | number;
+  col11?: string | number;
+  col12?: string | number;
+  col13?: string | number;
+  col14?: string | number;
+  col15?: string | number;
+  col16?: string | number;
+  col17?: string | number;
+  col18?: string | number;
+  col19?: string | number;
+  col20?: string | number;
+  col21?: string | number;
+  col22?: string | number;
+  col23?: string | number;
+  col24?: string | number;
+  col25?: string | number;
+  col26?: string | number;
+  col27?: string | number;
+  col28?: string | number;
+  col29?: string | number;
+  col30?: string | number;
+}
+
 export interface ProductInterface {
+  [key: string | number]: string | number | undefined;
+
   상품코드?: string;
   상품명?: string;
   상품가격?: number;
@@ -6,6 +53,7 @@ export interface ProductInterface {
   연관상품ID?: string;
 }
 export interface OrderInterface {
+  [key: string | number]: string | number | undefined;
   주문서양식?: string;
   주문명?: string;
   주문번호?: string;
@@ -19,6 +67,7 @@ export interface OrderInterface {
   택배사명?: string;
 }
 export interface ReleaseInterface {
+  [key: string | number]: string | number | undefined;
   출고코드?: string;
   출고수량?: number;
   출고상태?: string;
@@ -28,13 +77,17 @@ export interface ReleaseInterface {
   출고요청일자?: string;
   출고창고명?: string;
 }
+export interface RootInterface {
+  [key: string | number]: any;
 
-export interface DataInterface {
   데이터출처?: string;
   출고서파일명?: string;
   엑셀행순번?: number;
   매핑상태?: string;
   재고부족여부?: string;
+}
+
+export interface DataInterface extends RootInterface {
   상품?: ProductInterface;
   주문?: OrderInterface;
   출고?: ReleaseInterface;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- Table 설정 적용 + 로직 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- `getRowGrid`, `getColGrid` 함수를 Constants 에 만들었습니다
- `getColGrid` -> `['카테고리1', '카테고리2', '카테고리3']` 을 넣으면
```js
[{field: 'col1', headerName: '데이터출처', minWidth: 40},
{field: 'col2', headerName: '출고서파일명', minWidth: 100},
{field: 'col3', headerName: '엑셀행순번', minWidth: 40}]
```
이렇게 만들어줍니다
- `getRowGrid` 는 전체 data와 `getColGrid` 로 만들어진 column 데이터를 넣습니다
```js
[{id: 1, col1: '엑셀', col2: '테스트_콜로상사', col3: 1, col4: '주문취소', …}
{id: 2, col1: '엑셀', col2: '테스트_콜로상사', col3: '2', col4: '주문명매핑성공', …}
{id: 3, col1: '엑셀', col2: '테스트_콜로상사', col3: '3', col4: '주문명매핑성공', …}]
```
돌리면 이렇게 만들어집니다.

- interface 추가 하였습니다.
```js
export interface StringObjKey {
  [key: string | number]: string | number | undefined;
}
```
이 인터페이스는 객체의 [] 접근을 위해 추가하였습니다.
- DataInterface 를 수정하였습니다 (기존에 있던 카테고리들을 RootInterface 로 옮겨서 extends 로 상속받도록 함)
- Table 가로를 minWidth 로 설정하여 나오도록 했습니다
- Table row 데이터 있는곳만 스크롤 되도록 하였습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- mui 의 table 의 다양한 기능들이 있다는걸 알게되었습니다...

<br />

## :: 기타 질문 및 특이 사항

- 없습니다
